### PR TITLE
Clean up the file browser

### DIFF
--- a/md/filelist.md
+++ b/md/filelist.md
@@ -2,7 +2,6 @@
 ---
 
 # [Home](../index.html)
-# [Credits](/docs/Credits.html)
 # [Example](/docs/Example.html)
 # [FAQ](/docs/FAQ.html)
 # [Installation](/docs/Installation.html)

--- a/md/filelist.md
+++ b/md/filelist.md
@@ -2,7 +2,6 @@
 ---
 
 # [Home](../index.html)
-# [Example](/docs/Example.html)
 # [FAQ](/docs/FAQ.html)
 # [Installation](/docs/Installation.html)
 # [Tips](/docs/Tips.html)


### PR DESCRIPTION
Right now the file browser has two entries for Credits, so I removed one of them. I also removed example.md from the file browser, as I don't think there's a reason for it to be there, since it's meant to be used by the maintainers