### PR TITLE
Add favicon + Update distro test table + update a common issue

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="style.css" rel="stylesheet" type="text/css" media="all">
     <title>Sober Docs</title>
+    <link rel="icon" type="image/x-icon" href="images/sober.svg">
 </head>
 <body>
     <md-block src="md/nav.md">Markdown failed to load...</md-block>

--- a/docs/CommonIssues.html
+++ b/docs/CommonIssues.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
     <title>Sober Docs</title>
+    <link rel="icon" type="image/x-icon" href="../images/sober.svg">
 </head>
 <body>
   <md-block src="../md/nav.md">Markdown failed to load...</md-block>

--- a/docs/Contributors.html
+++ b/docs/Contributors.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
     <title>Sober Docs</title>
+    <link rel="icon" type="image/x-icon" href="../images/sober.svg">
 </head>
 <body>
   <md-block src="../md/nav.md">Markdown failed to load...</md-block>

--- a/docs/Example.html
+++ b/docs/Example.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
     <title>Sober Docs</title>
+    <link rel="icon" type="image/x-icon" href="../images/sober.svg">
 </head>
 <body>
   <md-block src="../md/nav.md">Markdown failed to load...</md-block>

--- a/docs/FAQ.html
+++ b/docs/FAQ.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
     <title>Sober Docs</title>
+    <link rel="icon" type="image/x-icon" href="../images/sober.svg">
 </head>
 <body>
   <md-block src="../md/nav.md">Markdown failed to load...</md-block>

--- a/docs/Installation.html
+++ b/docs/Installation.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
     <title>Sober Docs</title>
+    <link rel="icon" type="image/x-icon" href="../images/sober.svg">
 </head>
 <body>
   <md-block src="../md/nav.md">Markdown failed to load...</md-block>

--- a/docs/TestedDistroVersions.html
+++ b/docs/TestedDistroVersions.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
     <title>Sober Docs</title>
+    <link rel="icon" type="image/x-icon" href="../images/sober.svg">
 </head>
 <body>
   <md-block src="../md/nav.md">Markdown failed to load...</md-block>

--- a/docs/Tips.html
+++ b/docs/Tips.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
     <title>Sober Docs</title>
+    <link rel="icon" type="image/x-icon" href="../images/sober.svg">
 </head>
 <body>
   <md-block src="../md/nav.md">Markdown failed to load...</md-block>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="style.css" rel="stylesheet" type="text/css" media="all">
     <title>Sober Docs</title>
+    <link rel="icon" type="image/x-icon" href="images/sober.svg">
 </head>
 <body>
   <md-block src="md/nav.md">Markdown failed to load...</md-block>

--- a/md/common-issues.md
+++ b/md/common-issues.md
@@ -4,12 +4,14 @@
 
 ## RBXCRASH: OutOfMemory (Failed to allocate memory. size = [x], alignment = [y])
 
-That means your graphics card ran out of video memory that Sober is trying to load on. This is especially problematic for NVIDIA users because they have terrible written Linux drivers for VRAM handling. (There has also been reports of Intel Haswell and earlier iGPU users facing issues like this too)
+That means your graphics card ran out of video memory that Sober is trying to load on. This is especially problematic for NVIDIA users because the propritary drivers have terrible written Linux drivers for VRAM handling. (There has been reports that the open kernel for Turing+ don't have this issue. There has also been reports of Intel Haswell and earlier iGPU users facing issues like this too)
 
 The main culprit behind this is basically due to textures being loaded at the highest quality possible, which is the default setting.
 
 ### Solution
-Append the following FFlags into `~/.var/app/org.vinegarhq.Sober/data/sober/exe/ClientSettings/ClientAppSettings.json`
+The main solution would be using the open kernel drivers.
+
+If you don't have Turing+, append the following FFlags into `~/.var/app/org.vinegarhq.Sober/data/sober/exe/ClientSettings/ClientAppSettings.json`
 
 ```
 "DFIntTextureQualityOverride": 2,

--- a/md/common-issues.md
+++ b/md/common-issues.md
@@ -18,7 +18,7 @@ If you don't have Turing+ or non-NVIDIA hardware that is encountering this issue
 "DFFlagTextureQualityOverrideEnabled": true
 ```
 
-If it doesn't work, set the `"DFIntTextureQualityOverride"` FFlag to `1` instead. Otherwise, you are out of luck.
+If it doesn't work, set the `"DFIntTextureQualityOverride"` FFlag to `1` instead. Otherwise, you might be out of luck.
 
 ---
 

--- a/md/common-issues.md
+++ b/md/common-issues.md
@@ -18,6 +18,8 @@ If you don't have Turing+ or non-NVIDIA hardware that is encountering this issue
 "DFFlagTextureQualityOverrideEnabled": true
 ```
 
+If it doesn't work, set the `"DFIntTextureQualityOverride"` FFlag to `1` instead. Otherwise, you are out of luck.
+
 ---
 
 ## RBXCRASH: OutOfMemory (swOcc_alloc failed on [x] bytes [y] alignment)

--- a/md/common-issues.md
+++ b/md/common-issues.md
@@ -9,7 +9,7 @@ That means your graphics card ran out of video memory that Sober is trying to lo
 The main culprit behind this is basically due to textures being loaded at the highest quality possible, which is the default setting.
 
 ### Solution
-The main solution would be using the open kernel drivers.
+The main solution would be using the official open kernel drivers. (Not to be confused with Nouveau)
 
 If you don't have Turing+, append the following FFlags into `~/.var/app/org.vinegarhq.Sober/data/sober/exe/ClientSettings/ClientAppSettings.json`
 

--- a/md/common-issues.md
+++ b/md/common-issues.md
@@ -9,9 +9,9 @@ That means your graphics card ran out of video memory that Sober is trying to lo
 The main culprit behind this is basically due to textures being loaded at the highest quality possible, which is the default setting.
 
 ### Solution
-The main solution would be using the official open kernel drivers. (Not to be confused with Nouveau)
+If you have NVIDIA hardware and it is Turing+, the main solution would be using the official open kernel drivers. (Not to be confused with Nouveau)
 
-If you don't have Turing+, append the following FFlags into `~/.var/app/org.vinegarhq.Sober/data/sober/exe/ClientSettings/ClientAppSettings.json`
+If you don't have Turing+ or non-NVIDIA hardware that is encountering this issue, append the following FFlags into `~/.var/app/org.vinegarhq.Sober/data/sober/exe/ClientSettings/ClientAppSettings.json`
 
 ```
 "DFIntTextureQualityOverride": 2,

--- a/md/testedDistroVersions.md
+++ b/md/testedDistroVersions.md
@@ -49,7 +49,7 @@
 ### Manjaro
 | Test date | Test authored by                              | Test method               | Installs? | Runs? | Notes |
 | --------- | --------------------------------------------- | ------------------------- | --------- | ----- | ----- |
-| 11/08/24  | [kirbix (k1yrix)](https://github.com/k1yrix)  | VMware Workstation 17.6.1 | Yes       | Yes   |       |
+| 11/08/24  | [kirbix (k1yrix)](https://github.com/k1yrix)  | VMware Workstation 17.6.1 | Yes       | No    | Mesa too old to attach to X11, libEGL too old to know if screen is DRI3 capable; despite able to run barebones, unable to install (and therefore run) Roblox under these conditions (similar to Ubuntu 20.04 LTS problem) |
 
 ### openSUSE (Tumbleweed)
 | Test date | Test authored by                              | Test method               | Installs? | Runs? | Notes |

--- a/md/testedDistroVersions.md
+++ b/md/testedDistroVersions.md
@@ -54,4 +54,4 @@
 ### openSUSE (Tumbleweed)
 | Test date | Test authored by                              | Test method               | Installs? | Runs? | Notes |
 | --------- | --------------------------------------------- | ------------------------- | --------- | ----- | ----- |
-| TBA       |                                               |                           | TBA       | TBA   |       |
+| 11/08/24  | [kirbix (k1yrix)](https://github.com/k1yrix)  | VMware Workstation 17.6.1 | Yes       | Yes   |       |

--- a/md/testedDistroVersions.md
+++ b/md/testedDistroVersions.md
@@ -27,7 +27,7 @@
 | 41             | 11/01/24  | [kirbix (k1yrix)](https://github.com/k1yrix)  | Phyiscal machine               | Yes       | Yes   |       |
 
 ### openSUSE (Leap)
-| Tested version | Test date | Test authored by                              | Method of testing      | Installs? | Runs? | Notes |
+| Tested version | Test date | Test authored by                              | Test method            | Installs? | Runs? | Notes |
 | -------------- | --------- | --------------------------------------------- | ---------------------- | --------- | ----- | ----- |
 | TBA            | TBA       |                                               |                        | TBA       | TBA   |       |
 
@@ -37,11 +37,21 @@
 > Rolling release distros usually don't have a point release version. For this, it will be tested peridotically. On the table, the test date is the most contextical.
 
 ### Arch Linux
-| Test date | Test authored by                              | Method of testing      | Installs? | Runs? | Notes |
-| --------- | --------------------------------------------- | ---------------------- | --------- | ----- | ----- |
-| TBA       |                                               |                        | TBA       | TBA   |       |
+| Test date | Test authored by                              | Test method               | Installs? | Runs? | Notes |
+| --------- | --------------------------------------------- | ------------------------- | --------- | ----- | ----- |
+| 11/08/24  | [kirbix (k1yrix)](https://github.com/k1yrix)  | VMware Workstation 17.6.1 | Yes       | Yes   |       |
+
+### EndeavourOS
+| Test date | Test authored by                              | Test method               | Installs? | Runs? | Notes |
+| --------- | --------------------------------------------- | ------------------------- | --------- | ----- | ----- |
+| 11/08/24  | [kirbix (k1yrix)](https://github.com/k1yrix)  | VMware Workstation 17.6.1 | Yes       | Yes   |       |
+
+### Manjaro
+| Test date | Test authored by                              | Test method               | Installs? | Runs? | Notes |
+| --------- | --------------------------------------------- | ------------------------- | --------- | ----- | ----- |
+| 11/08/24  | [kirbix (k1yrix)](https://github.com/k1yrix)  | VMware Workstation 17.6.1 | Yes       | Yes   |       |
 
 ### openSUSE (Tumbleweed)
-| Test date | Test authored by                              | Method of testing      | Installs? | Runs? | Notes |
-| --------- | --------------------------------------------- | ---------------------- | --------- | ----- | ----- |
-| TBA       |                                               |                        | TBA       | TBA   |       |
+| Test date | Test authored by                              | Test method               | Installs? | Runs? | Notes |
+| --------- | --------------------------------------------- | ------------------------- | --------- | ----- | ----- |
+| TBA       |                                               |                           | TBA       | TBA   |       |

--- a/md/testedDistroVersions.md
+++ b/md/testedDistroVersions.md
@@ -49,7 +49,7 @@
 ### Manjaro
 | Test date | Test authored by                              | Test method               | Installs? | Runs? | Notes |
 | --------- | --------------------------------------------- | ------------------------- | --------- | ----- | ----- |
-| 11/08/24  | [kirbix (k1yrix)](https://github.com/k1yrix)  | VMware Workstation 17.6.1 | Yes       | No    | Mesa unable to attach to X11, libEGL unable to know if screen is DRI3 capable; despite able to run barebones, unable to install (and therefore run) Roblox under these conditions (relevantly similar to Ubuntu 20.04 LTS problem) |
+| 11/08/24  | [kirbix (k1yrix)](https://github.com/k1yrix)  | VMware Workstation 17.6.1 | Yes       | Inconclusive | For some reason, Manjaro faced the relevant issue when Ubuntu 20.04 LTS was tested. I have no idea what is going on with Mesa nor I have no idea who's fault is it that causes this issue, despite it should be an up-to-date version/system. Will require further testing. |
 
 ### openSUSE (Tumbleweed)
 | Test date | Test authored by                              | Test method               | Installs? | Runs? | Notes |

--- a/md/testedDistroVersions.md
+++ b/md/testedDistroVersions.md
@@ -49,7 +49,7 @@
 ### Manjaro
 | Test date | Test authored by                              | Test method               | Installs? | Runs? | Notes |
 | --------- | --------------------------------------------- | ------------------------- | --------- | ----- | ----- |
-| 11/08/24  | [kirbix (k1yrix)](https://github.com/k1yrix)  | VMware Workstation 17.6.1 | Yes       | No    | Mesa too old to attach to X11, libEGL too old to know if screen is DRI3 capable; despite able to run barebones, unable to install (and therefore run) Roblox under these conditions (similar to Ubuntu 20.04 LTS problem) |
+| 11/08/24  | [kirbix (k1yrix)](https://github.com/k1yrix)  | VMware Workstation 17.6.1 | Yes       | No    | Mesa unable to attach to X11, libEGL unable to know if screen is DRI3 capable; despite able to run barebones, unable to install (and therefore run) Roblox under these conditions (relevantly similar to Ubuntu 20.04 LTS problem) |
 
 ### openSUSE (Tumbleweed)
 | Test date | Test authored by                              | Test method               | Installs? | Runs? | Notes |


### PR DESCRIPTION
This adds a favicon on all html pages

---

The common issue update is regarding the VRAM issue in response to this:
![image](https://github.com/user-attachments/assets/b66d4373-f2b7-454d-baea-0bdf6ce6ff27)

---

Tested distros update:
- Added EndavourOS
- Added Manjaro
- Added openSUSE Tumbleweed