### PR TITLE
Correct FMOD API error section

### DIFF
--- a/md/common-issues.md
+++ b/md/common-issues.md
@@ -63,13 +63,11 @@ See above.
 ---
 
 ## FMOD API error
-FMOD freaked out because something sound-related horribly went wrong and did not know what to do, so it crashed.
-
-### Solution
-Unfortunately there isn't any that could help this problem.
+Roblox uses FMOD improperly, resulting in FMOD errors sometimes being spammed into the FLog. These errors happen on real Android devices as well, and are usually not a problem.
 
 ### Affected games
 - [Rivals](https://www.roblox.com/games/17625359962)
+- [a dusty trip](https://www.roblox.com/games/16389395869)
 
 ---
 


### PR DESCRIPTION
FMOD errors are normal and non-fatal on Roblox. FMOD_RESULT 31 corresponds to FMOD_ERR_INVALID_PARAM, meaning that Roblox has passed an incorrect parameter to the setLoopPoints function. 

(taken from Waydroid running Roblox v650)
![Screenshot_20241115_201858](https://github.com/user-attachments/assets/9fe5be3d-1fd7-4182-a0c5-965efa7431db)
